### PR TITLE
upgrade ssh from rsa to Ed25519

### DIFF
--- a/LAPTOP_SETUP.md
+++ b/LAPTOP_SETUP.md
@@ -33,7 +33,8 @@ Laptop setup for ruby/node/rust development
        Keys](https://gitlab.com/-/profile/keys) as per instructions in
        https://docs.gitlab.com/ee/ssh/#rsa-ssh-keys
      ```
-     ssh-keygen -t rsa -b 2048 -C "my UNIQUE NAME key"
+     mkdir -p ~/.ssh && ssh-keygen -t ed25519 -o -a 100 -f ~/.ssh/id_ed25519 -C "name of key OR TYPE_YOUR_EMAIL@HERE.com"
+
      ```
     1. setup sane git defaults
     ```


### PR DESCRIPTION
seems like it is time to up SSH key from RSA to Ed25519, since 2048-length is not providing sufficient security these days
https://medium.com/risan/upgrade-your-ssh-key-to-ed25519-c6e8d60d3c54